### PR TITLE
Arm docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ OpenBT relies on OpenMPI, which is not compatible with Windows. Thus you can wor
 
 **macOS Users**: 
 
-There is currently no wheel in PyPI for macs with ARM processors.  While we hope
+There is currently no wheel in PyPI for macs with ARM processors.  While we intend
 to have a permanent solution to this issue soon (See Issue #6), at present
 affected users must manually build and install the package using the
 procedure given here.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ Build the openbtmixing command line tools (CLTs):
   `export PATH=$PATH:$HOME/local/OpenBT/bin`
 * Run `which openbtcli` and confirm that the `openbtcli` CLT is found and installed
   in the expected location
-* Run `/path/to/OpenBT/tools/test_python_installation.py` and confirm that all tests are
-  passing.
 
 Note that users might want to add the alteration of `PATH` to a shell
 configuration file such as `.zshrc` so that it is automatically setup when the
@@ -67,6 +65,8 @@ your target Python and activate the environment.
 * `python -m build --sdist`
 * `python -m pip install dist/openbtmixing-<version>.tar.gz`
 * `python -m pip list`
+* Run `/path/to/OpenBT/tools/test_python_installation.py` and confirm that all tests are
+  passing.
 
 # Installation for R Users:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Build the openbtmixing command line tools (CLTs):
   `export PATH=$PATH:$HOME/local/OpenBT/bin`
 * Run `which openbtcli` and confirm that the `openbtcli` CLT is found and installed
   in the expected location
-* Run `./tools/test_python_installation.py` and confirm that all tests are
+* Run `/path/to/OpenBT/tools/test_python_installation.py` and confirm that all tests are
   passing.
 
 Note that users might want to add the alteration of `PATH` to a shell

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ OpenBT relies on OpenMPI, which is not compatible with Windows. Thus you can wor
 
 There is currently no wheel in PyPI for macs with ARM processors.  While we hope
 to have a permanent solution to this issue soon (See Issue #6), at present
-affected users must manually build and install the package using the following
-procedure.
+affected users must manually build and install the package using the
+procedure given here.
 
 We assume the use of the [homebrew package manager](https://brew.sh).  For
 ARM-based macs, homebrew installs packages in `/opt/homebrew`.  Please adapt
@@ -35,12 +35,12 @@ Preinstall requirements:
 
 Confirm that installation is valid:
 * Run `which mpirun` and confirm that `mpirun` is found and located in a
-  reasonable location (e.g., `/opt/homebrew/bin/mpirun`)
+  reasonable location (e.g., `/opt/homebrew/bin/mpirun`).
 * Run `ls /opt/homebrew/include/eigen3/Eigen` and confirm that you see an
   installation by confirming that folders such as `QR`, `SVD`, and `Dense` are
   shown.
 
-Build the openbtmixing command line tools:
+Build the openbtmixing command line tools (CLTs):
 * Clone the [openbtmixing repository](https://github.com/jcyannotty/OpenBT) on
   the machine that requires the installation
 * `cd /path/to/OpenBT`
@@ -48,11 +48,13 @@ Build the openbtmixing command line tools:
 * `CPATH=/opt/homebrew/include/eigen3 ./tools/build_openbt_clt.sh ~/local/OpenBT`
 * Run `ls ~/local/OpenBT/bin` and confirm that you see `openbtcli` and similar
 * Run `ls ~/local/OpenBT/lib` and confirm that you see `libtree.dylib` and similar
-* Add to PATH with something like `export PATH=$PATH:$HOME/local/OpenBT/bin`
-* Run `which openbtcli` and confirm that `openbtcli` is found and installed in
-  the expected location
+* Add location of the CLTs to `PATH` with something like
+  `export PATH=$PATH:$HOME/local/OpenBT/bin`
+* Run `which openbtcli` and confirm that the `openbtcli` CLT is found and installed
+  in the expected location
 * Run `./tools/test_python_installation.py` and confirm that all tests are
   passing.
+
 Note that users might want to add the alteration of `PATH` to a shell
 configuration file such as `.zshrc` so that it is automatically setup when the
 shell is started.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,59 @@ You can work with the BART-based model mixing method via the Taweret python pack
 
 OpenBT relies on OpenMPI, which is not compatible with Windows. Thus you can work with Taweret by using Windows Subsystem for Linux (WSL). See instructions below for installing WSL.
 
+**macOS Users**: 
+
+There is currently no wheel in PyPI for macs with ARM processors.  While we hope
+to have a permanent solution to this issue soon (See Issue #6), at present
+affected users must manually build and install the package using the following
+procedure.
+
+We assume the use of the [homebrew package manager](https://brew.sh).  For
+ARM-based macs, homebrew installs packages in `/opt/homebrew`.  Please adapt
+appropriately the following if you are installing by other means or if homebrew
+installs to a different location.
+
+Preinstall requirements:
+* Install homebrew if not already done so
+* `brew install open-mpi`
+* `brew install autoconf`
+* `brew install autoconf-archive`
+* `brew install automake`
+* `brew install libtool`
+* `brew install eigen`
+
+Confirm that installation is valid:
+* Run `which mpirun` and confirm that `mpirun` is found and located in a
+  reasonable location (e.g., `/opt/homebrew/bin/mpirun`)
+* Run `ls /opt/homebrew/include/eigen3/Eigen` and confirm that you see an
+  installation by confirming that folders such as `QR`, `SVD`, and `Dense` are
+  shown.
+
+Build the openbtmixing command line tools:
+* Clone the [openbtmixing repository](https://github.com/jcyannotty/OpenBT) on
+  the machine that requires the installation
+* `cd /path/to/OpenBT`
+* `mkdir ~/local/OpenBT`
+* `CPATH=/opt/homebrew/include/eigen3 ./tools/build_openbt_clt.sh ~/local/OpenBT`
+* Run `ls ~/local/OpenBT/bin` and confirm that you see `openbtcli` and similar
+* Run `ls ~/local/OpenBT/lib` and confirm that you see `libtree.dylib` and similar
+* Add to PATH with something like `export PATH=$PATH:$HOME/local/OpenBT/bin`
+* Run `which openbtcli` and confirm that `openbtcli` is found and installed in
+  the expected location
+* Run `./tools/test_python_installation.py` and confirm that all tests are
+  passing.
+Note that users might want to add the alteration of `PATH` to a shell
+configuration file such as `.zshrc` so that it is automatically setup when the
+shell is started.
+
+To build and install the package, please first setup a virtual environment with
+your target Python and activate the environment.
+* `cd /path/to/OpenBT/openbtmixing_pypkg`
+* `python -m pip install --upgrade pip`
+* `python -m pip install build`
+* `python -m build --sdist`
+* `python -m pip install dist/openbtmixing-<version>.tar.gz`
+* `python -m pip list`
 
 # Installation for R Users:
 


### PR DESCRIPTION
Taweret v1.1.0 is now in PyPI and it still uses the original OpenBT installation scheme from pre-compiled binary wheels.  There are two macOS/arm64 wheels available (v10.9 and 12.0). If I remember correctly, they were uploaded because I was having issues on my machine, but that we never finalized those so that they might be "unofficial" wheels. Therefore, the user community should likely not be using them.

In this branch, I have prepared a procedure for manually installing the package with OpenMPI on MacOS/arm64.  Alexandra and I have tested it independently.

@jcyannotty Until Issue #6 is implemented, we propose merging this branch into your `main` and removing the macOS/arm64 wheels from PyPI if possible.  Please let us know your thoughts on this.